### PR TITLE
Update http-server 0.8.5 -> 0.9.0

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -22,7 +22,7 @@
     "babelify": "^7.2.0",
     "browserify": "^12.0.1",
     "browserify-hmr": "^0.3.1",
-    "http-server": "^0.8.5",
+    "http-server": "^0.9.0",
     "uglify-js": "^2.5.0",
     "vue-hot-reload-api": "^1.2.2",
     "vueify": "^8.0.0",


### PR DESCRIPTION
http-server throws error `The header content contains invalid characters` on Windows.
https://github.com/indexzero/http-server/issues/244

Update http-server to solve the problem.
