### PR TITLE
Use full (standalone) version of Vue (fixes #17)

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -31,5 +31,8 @@
       "vueify",
       "babelify"
     ]
+  },
+  "browser": {
+    "vue": "vue/dist/vue.common.js"
   }
 }


### PR DESCRIPTION
This maintains consistency with webpack-simple and also probably makes sense, given that this project and is only meant for quick, unrestrained prototyping anyway.